### PR TITLE
feat: add basic tracing spans to index and search endpoints

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2,6 +2,8 @@ from jina import Executor, requests
 from typing import Optional, Dict, List, Tuple, Union
 from docarray import DocumentArray
 from jina.logging.logger import JinaLogger
+from opentelemetry.trace import NoOpTracer
+import json
 
 
 class QdrantIndexer(Executor):
@@ -62,18 +64,24 @@ class QdrantIndexer(Executor):
         )
 
         self.logger = JinaLogger(self.metas.name)
+        if not self.tracer:
+            self.tracer = NoOpTracer()
 
     @requests(on='/index')
-    def index(self, docs: DocumentArray, **kwargs):
+    def index(self, docs: DocumentArray, tracing_context, **kwargs):
         """Index new documents
         :param docs: the Documents to index
         """
-        self._index.extend(docs)
+        with self.tracer.start_as_current_span(
+            'qdrant_index', context=tracing_context
+        ) as span:
+            self._index.extend(docs)
 
     @requests(on='/search')
     def search(
         self,
         docs: 'DocumentArray',
+        tracing_context,
         parameters: Dict = {},
         **kwargs,
     ):
@@ -84,13 +92,18 @@ class QdrantIndexer(Executor):
         :param kwargs: additional kwargs for the endpoint
 
         """
-        
-        match_args = (
+        with self.tracer.start_as_current_span(
+            'qdrant_search', context=tracing_context
+        ) as span:
+            match_args = (
                 {**self._match_args, **parameters}
                 if parameters is not None
                 else self._match_args
             )
-        docs.match(self._index, **match_args)
+
+            span.set_attribute('match_args', json.dumps(match_args))
+            docs.match(self._index, **match_args)
+            span.set_attribute('len_matched_docs', len(docs['@m']))
 
     @requests(on='/delete')
     def delete(self, parameters: Dict, **kwargs):

--- a/executor.py
+++ b/executor.py
@@ -1,9 +1,10 @@
-from jina import Executor, requests
-from typing import Optional, Dict, List, Tuple, Union
+import json
+from typing import Dict, List, Optional, Tuple, Union
+
 from docarray import DocumentArray
+from jina import Executor, requests
 from jina.logging.logger import JinaLogger
 from opentelemetry.trace import NoOpTracer
-import json
 
 
 class QdrantIndexer(Executor):
@@ -69,7 +70,7 @@ class QdrantIndexer(Executor):
             self.tracer = NoOpTracer()
 
     @requests(on='/index')
-    def index(self, docs: DocumentArray, tracing_context, **kwargs):
+    def index(self, docs: DocumentArray, tracing_context=None, **kwargs):
         """Index new documents
         :param docs: the Documents to index
         """
@@ -82,7 +83,7 @@ class QdrantIndexer(Executor):
     def search(
         self,
         docs: 'DocumentArray',
-        tracing_context,
+        tracing_context=None,
         parameters: Dict = {},
         **kwargs,
     ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[qdrant]>=0.19.0
-jina>=3.11.2
+jina>=3.12.0


### PR DESCRIPTION
- add `NoOpTracer` if tracing is disabled so that the operations with `self.tracer` become no-op code. The `NoOpTracer` is part of the `opentelemetry-api` library downloaded by jina `standard` requirements.
- add spans to the index and search endpoints with basic attributes. The attributes can be improved.

This PR needs to be merged after once jina 3.11.1 has been released. I will link the blog post when ready.