### PR TITLE
feat: add list like parameter

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -21,6 +21,7 @@ class QdrantIndexer(Executor):
         scroll_batch_size: int = 64,
         serialize_config: Optional[Dict] = None,
         columns: Optional[Union[List[Tuple[str, str]], Dict[str, str]]] = None,
+        list_like: bool = False,
         **kwargs,
     ):
         """
@@ -48,6 +49,7 @@ class QdrantIndexer(Executor):
             storage='qdrant',
             config={
                 'collection_name': collection_name,
+                'list_like': list_like,
                 'host': host,
                 'port': port,
                 'n_dim': n_dim,

--- a/executor.py
+++ b/executor.py
@@ -58,6 +58,7 @@ class QdrantIndexer(Executor):
                 'full_scan_threshold': full_scan_threshold,
                 'serialize_config': serialize_config or {},
                 'columns': columns,
+                'list_like': False,
             },
         )
 

--- a/executor.py
+++ b/executor.py
@@ -128,7 +128,6 @@ class QdrantIndexer(Executor):
         specifications in the `find` method of `DocumentArray` in the docs https://docarray.jina.ai/fundamentals/documentarray/find/#filter-with-query-operators
         :param parameters: parameters of the request
         """
-        print(f"parameters['query'] = {parameters['query']}")
         return self._index.find(parameters['query'])
 
     @requests(on='/fill_embedding')

--- a/executor.py
+++ b/executor.py
@@ -58,7 +58,6 @@ class QdrantIndexer(Executor):
                 'full_scan_threshold': full_scan_threshold,
                 'serialize_config': serialize_config or {},
                 'columns': columns,
-                'list_like': False,
             },
         )
 
@@ -85,7 +84,7 @@ class QdrantIndexer(Executor):
         :param kwargs: additional kwargs for the endpoint
 
         """
-        
+
         match_args = (
                 {**self._match_args, **parameters}
                 if parameters is not None

--- a/executor.py
+++ b/executor.py
@@ -58,7 +58,6 @@ class QdrantIndexer(Executor):
                 'full_scan_threshold': full_scan_threshold,
                 'serialize_config': serialize_config or {},
                 'columns': columns,
-                'list_like': False,
             },
         )
 

--- a/executor.py
+++ b/executor.py
@@ -21,7 +21,6 @@ class QdrantIndexer(Executor):
         scroll_batch_size: int = 64,
         serialize_config: Optional[Dict] = None,
         columns: Optional[Union[List[Tuple[str, str]], Dict[str, str]]] = None,
-        list_like: bool = False,
         **kwargs,
     ):
         """
@@ -49,7 +48,6 @@ class QdrantIndexer(Executor):
             storage='qdrant',
             config={
                 'collection_name': collection_name,
-                'list_like': list_like,
                 'host': host,
                 'port': port,
                 'n_dim': n_dim,
@@ -60,6 +58,7 @@ class QdrantIndexer(Executor):
                 'full_scan_threshold': full_scan_threshold,
                 'serialize_config': serialize_config or {},
                 'columns': columns,
+                'list_like': False,
             },
         )
 
@@ -129,6 +128,7 @@ class QdrantIndexer(Executor):
         specifications in the `find` method of `DocumentArray` in the docs https://docarray.jina.ai/fundamentals/documentarray/find/#filter-with-query-operators
         :param parameters: parameters of the request
         """
+        print(f"parameters['query'] = {parameters['query']}")
         return self._index.find(parameters['query'])
 
     @requests(on='/fill_embedding')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-docarray[qdrant]>=0.19.0
+docarray[qdrant]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-docarray[qdrant]>=0.19.0
-qdrant-client==0.10.3
+docarray[qdrant]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docarray[qdrant]>=0.19.0
+qdrant-client==0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[qdrant]>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-docarray[qdrant]
+docarray[qdrant]>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 docarray[qdrant]
-docarray>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docarray[qdrant]
+git+https://github.com/jina-ai/jina.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docarray[qdrant]
+docarray>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[qdrant]>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-docarray[qdrant]
+docarray[qdrant]>=0.19.0
 git+https://github.com/jina-ai/jina.git@master

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qdrant:
-    image: qdrant/qdrant:v0.7.0
+    image: qdrant/qdrant:v0.10.1
     ports:
       - "6333:6333"
     ulimits: # Only required for tests, as there are a lot of collections created

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qdrant:
-    image: qdrant/qdrant:v0.10.3
+    image: qdrant/qdrant:v0.10.1
     ports:
       - "6333:6333"
     ulimits: # Only required for tests, as there are a lot of collections created

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qdrant:
-    image: qdrant/qdrant:v0.10.0
+    image: qdrant/qdrant:v0.10.1
     ports:
       - "6333:6333"
     ulimits: # Only required for tests, as there are a lot of collections created

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qdrant:
-    image: qdrant/qdrant:v0.10.1
+    image: qdrant/qdrant:v0.10.3
     ports:
       - "6333:6333"
     ulimits: # Only required for tests, as there are a lot of collections created

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   qdrant:
-    image: qdrant/qdrant:v0.10.1
+    image: qdrant/qdrant:v0.10.0
     ports:
       - "6333:6333"
     ulimits: # Only required for tests, as there are a lot of collections created

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
 pytest==7.1.2
-docarray>=0.19.0
-qdrant-client==0.10.3
+docarray>=0.13.18

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
+qdrant-client==0.10.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 pytest==7.1.2
-docarray>=0.19.0
+docarray>=0.13.18

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 pytest==7.1.2
-docarray>=0.13.18
+docarray>=0.19.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.2
 docarray>=0.13.18
+git+https://github.com/jina-ai/jina.git@master

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
-docarray>=0.13.18
+docarray>=0.19.0
 git+https://github.com/jina-ai/jina.git@master

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -97,18 +97,19 @@ def test_fill_embeddings(docker_compose):
 
 def test_filter(docker_compose):
     docs = DocumentArray.empty(5)
-    docs[0].text = 'hello'
-    docs[1].text = 'world'
+    docs[0].tags['text'] = 'hello'
+    docs[1].tags['text'] = 'world'
     docs[2].tags['x'] = 0.3
     docs[2].tags['y'] = 0.6
     docs[3].tags['x'] = 0.8
 
-    qindex = QdrantIndexer(collection_name='test')
+    qindex = QdrantIndexer(collection_name='test', columns={'text': 'str'})
     qindex.index(docs)
 
-    result = qindex.filter(parameters={'query': {'text': {'$eq': 'hello'}}})
+    query = {'must': [{'key': 'text', 'match': {'value': 'hello'}}]}
+    result = qindex.filter(parameters={'query': query})
     assert len(result) == 1
-    assert result[0].text == 'hello'
+    assert result[0].tags['text'] == 'hello'
 
     result = docs.find({'tags__x': {'$gte': 0.5}})
     assert len(result) == 1

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -158,10 +158,10 @@ def test_persistence(docs, docker_compose):
 
 
 @pytest.mark.parametrize(
-    'metric, metric_name',
-    [('euclidean', 'euclid_similarity'), ('cosine', 'cosine_similarity')],
+    'metric, metric_name, reverse',
+    [('euclidean', 'euclid_distance', False), ('cosine', 'cosine_similarity', True)],
 )
-def test_search(metric, metric_name, docs, docker_compose):
+def test_search(metric, metric_name, reverse, docs, docker_compose):
     # test general/normal case
     indexer = QdrantIndexer(collection_name='test', distance=metric)
     indexer.index(docs)
@@ -170,7 +170,8 @@ def test_search(metric, metric_name, docs, docker_compose):
 
     for doc in query:
         similarities = [t[metric_name].value for t in doc.matches[:, 'scores']]
-        assert sorted(similarities, reverse=True) == similarities
+        assert sorted(similarities, reverse=reverse) == similarities
+        assert len(similarities) == len(docs)
 
 
 def test_clear(docs, docker_compose):

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -160,7 +160,7 @@ def test_persistence(docs, docker_compose):
 
 @pytest.mark.parametrize(
     'metric, metric_name, reverse',
-    [('euclidean', 'euclid_distance', False), ('cosine', 'cosine_similarity', True)],
+    [('euclidean', 'euclid_similarity', False), ('cosine', 'cosine_similarity', True)],
 )
 def test_search(metric, metric_name, reverse, docs, docker_compose):
     # test general/normal case

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -79,7 +79,6 @@ def test_update(docs, update_docs, docker_compose):
 
     # update first doc
     qindex.update(update_docs)
-    assert qindex._index[0].id == 'doc1'
     assert qindex._index['doc1'].text == 'modified'
 
 


### PR DESCRIPTION
Previously, a `list_like` parameter has been added to the storage backends, this parameter we now want to introduce to the `QdrantIndexer`. 
This way, the list-like behaviour can be disabled the the [performance issues regarding the list-like behaviour](https://docarray.jina.ai/advanced/document-store/#performance-issue-caused-by-list-like-structure) removed ().

Solving this issue: https://github.com/docarray/docarray/issues/802