### PR TITLE
fix: update jina version for tests requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-jina>=3.11.2
+jina>=3.12.0


### PR DESCRIPTION
Jina version for the `tests` package was not updated in #10 .